### PR TITLE
Add force-directed layout option to json_mindmap

### DIFF
--- a/json_mindmap.py
+++ b/json_mindmap.py
@@ -28,16 +28,31 @@ def radial_positions(graph):
     return nx.shell_layout(graph, nlist=shells)
 
 
-def main(path):
+def choose_layout(graph, algo="spring", seed=42):
+    if algo == "spring":
+        return nx.spring_layout(graph, k=0.6, iterations=400, seed=seed)
+    elif algo == "kamada":
+        return nx.kamada_kawai_layout(graph)
+    return radial_positions(graph)
+
+
+def main(path, layout="spring"):
     if nx is None or plt is None:
         raise RuntimeError("networkx and matplotlib are required")
     with open(path, encoding="utf-8") as fh:
         data = json.load(fh)
     g = nx.Graph()
     build_graph(data, g)
-    pos = radial_positions(g)
+    pos = choose_layout(g, layout)
     plt.figure(figsize=(18, 14))
-    nx.draw_networkx(g, pos, node_size=50, font_size=6, edge_color="#888888")
+    nx.draw_networkx(
+        g,
+        pos,
+        node_size=60,
+        font_size=6,
+        edge_color="#888888",
+        linewidths=0.3,
+    )
     plt.axis("off")
     plt.tight_layout()
     out_pdf = os.path.splitext(os.path.basename(path))[0] + ".pdf"
@@ -47,6 +62,8 @@ def main(path):
 
 if __name__ == "__main__":
     if len(sys.argv) < 2:
-        print("Usage: python json_mindmap.py <json_file>")
+        print("Usage: python json_mindmap.py <json_file> [layout]")
         sys.exit(1)
-    main(sys.argv[1])
+    path = sys.argv[1]
+    layout = sys.argv[2] if len(sys.argv) > 2 else "spring"
+    main(path, layout)


### PR DESCRIPTION
## Summary
- add `choose_layout` helper that supports `spring` and `kamada` algorithms
- allow selecting layout via CLI argument and default to spring layout
- tweak drawing parameters for better spacing

## Testing
- `python -m py_compile json_mindmap.py`
- `python json_mindmap.py output/medizin_overview.json spring` *(fails: networkx and matplotlib missing)*


------
https://chatgpt.com/codex/tasks/task_e_6876ad99ebc48324b7eb5c1a7a7a1c36